### PR TITLE
fix: Apply rule SC123 - Avoid unused local variables

### DIFF
--- a/ContactHelper.cls
+++ b/ContactHelper.cls
@@ -1,7 +1,6 @@
 public class ContactHelper {
 
     public void createContacts(List<String> names) {
-        String logPrefix = 'ContactCreation'; // ✅ Unused
         Integer totalCreated = 0;
 
         for (String name : names) {
@@ -9,7 +8,5 @@ public class ContactHelper {
             insert c;
             totalCreated++;
         }
-
-        Boolean debugFlag = false; // ✅ Unused
     }
 }


### PR DESCRIPTION
This PR fixes the following rule:

**Avoid unused local variables**

Remove local variables that are declared but never used.